### PR TITLE
test: fix Windows line ending in snapshot restore assertion

### DIFF
--- a/tests/guardian.test.ts
+++ b/tests/guardian.test.ts
@@ -78,7 +78,7 @@ describe("guardian", () => {
 
     await manager.restoreSnapshot(snapshot.id);
     const restored = await fs.readFile(path.join(root, "file.txt"), "utf8");
-    expect(restored).toBe("base\n");
+    expect(restored.replace(/\r\n/g, "\n")).toBe("base\n");
 
     await fs.writeFile(snapshot.patchPath, "tampered", "utf8");
     await expect(manager.restoreSnapshot(snapshot.id)).rejects.toThrow("Snapshot checksum mismatch: working diff");


### PR DESCRIPTION
## Summary
- normalize restored file line endings in snapshot restore test
- prevents false failures on windows-latest matrix jobs

## Validation
- npm run lint
- npm test