### PR TITLE
chore: finalize v0.1.2 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.2 - 2026-02-21
+
+- Hotfix: normalize restored snapshot line ending assertion for Windows CI.
+- Confirmed `main` cross-platform matrix green after v0.1.1 merge.
+
 ## 0.1.1 - 2026-02-21
 
 - Added Prompt Compiler pipeline (`IntentIR`, diagnostics, auto-correct) and wired it into `salacia plan`.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm i -g salacia
 salacia init
 ```
 
-## CLI (v0.1.1)
+## CLI (v0.1.2)
 
 ```bash
 salacia init
@@ -108,7 +108,7 @@ See [SECURITY.md](SECURITY.md) for incident response and key rotation.
 
 ## Release Policy
 
-- Stable release in scope: GitHub release tag `v0.1.1`
+- Stable release in scope: GitHub release tag `v0.1.2`
 - npm public publish is intentionally out of scope for this cycle
 - Release is blocked unless CI and release gate pass
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,13 +1,13 @@
 # Release Procedure
 
-## Stable v0.1.1 Flow
+## Stable v0.1.2 Flow
 
 1. Create/update integration branch `codex/salacia-v0.1-final`.
 2. Pass CI matrix (`ubuntu/macos/windows` x `node 20/22/24`).
 3. Run release gate with convergence evidence.
 4. Merge to `main` via PR.
 5. Ensure prompt metamorphic gate is green.
-6. Tag `v0.1.1`.
+6. Tag `v0.1.2`.
 7. Publish GitHub Release with changelog and evidence links.
 
 ## Mandatory Gate Conditions
@@ -30,6 +30,6 @@ node scripts/release-gate.mjs --plan <plan.json> --exec <exec.json> --require-co
 Create tag and push:
 
 ```bash
-git tag -a v0.1.1 -m "Salacia v0.1.1"
-git push origin v0.1.1
+git tag -a v0.1.2 -m "Salacia v0.1.2"
+git push origin v0.1.2
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "salacia",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "salacia",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.50",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "salacia",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Salacia - repo-first Agentic Engineering OS",
   "type": "module",
   "license": "Apache-2.0",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -31,7 +31,7 @@ import { optimizePrompts } from "../prompt/optimize.js";
 import { buildSalaciaMcpServerDescription, runSalaciaMcpServer } from "../protocols/mcp-server.js";
 
 const program = new Command();
-program.name("salacia").description("Salacia v0.1.1 - repo-first Agentic Engineering OS").version("0.1.1");
+program.name("salacia").description("Salacia v0.1.2 - repo-first Agentic Engineering OS").version("0.1.2");
 
 function emit(data: unknown, asJson: boolean): void {
   if (asJson) {

--- a/src/protocols/mcp-server.ts
+++ b/src/protocols/mcp-server.ts
@@ -14,16 +14,16 @@ export interface McpServerDescription {
 }
 
 export async function buildSalaciaMcpServerDescription(): Promise<McpServerDescription> {
-  const gateway = new McpGateway({ serverName: "salacia-mcp", serverVersion: "0.1.1" });
+  const gateway = new McpGateway({ serverName: "salacia-mcp", serverVersion: "0.1.2" });
   return {
     name: "salacia-mcp",
-    version: "0.1.1",
+    version: "0.1.2",
     tools: gateway.getDefaultTools()
   };
 }
 
 export async function runSalaciaMcpServer(cwd = process.cwd()): Promise<void> {
-  const gateway = new McpGateway({ serverName: "salacia-mcp", serverVersion: "0.1.1" });
+  const gateway = new McpGateway({ serverName: "salacia-mcp", serverVersion: "0.1.2" });
 
   await gateway.startStdioServer({
     contractValidate: async ({ path: filePath }) => {

--- a/src/protocols/mcp.ts
+++ b/src/protocols/mcp.ts
@@ -126,7 +126,7 @@ export async function callSalaciaMcpTool(options: {
     cwd: options.cwd
   });
 
-  const client = new Client({ name: "salacia-mcp-client", version: "0.1.1" });
+  const client = new Client({ name: "salacia-mcp-client", version: "0.1.2" });
 
   try {
     await client.connect(transport);


### PR DESCRIPTION
## Summary
- bump package/cli/protocol versions to 0.1.2
- add 0.1.2 changelog entry
- align release docs/readme tag references to v0.1.2

## Validation
- npm run lint
- npm test
- npm run build
- npm run smoke