### PR TITLE
ci: keep advisor convergence local-only (mock in GitHub workflows)

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -3,12 +3,6 @@ name: Release Gate
 on:
   pull_request:
   workflow_dispatch:
-    inputs:
-      external_advisors:
-        description: "Run Claude/Gemini external advisors"
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   release-gate:
@@ -59,35 +53,23 @@ jobs:
           }
           JSON
 
-      - name: Prepare advisors (mock by default)
+      - name: Prepare advisors (mock-only)
         shell: bash
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.external_advisors }}" = "true" ]; then
-            echo "Using real advisor scripts"
-          else
-            printf '%s\n' \
-              '#!/usr/bin/env node' \
-              'console.log(JSON.stringify({ vote: "approve", summary: "mock claude approve", evidenceRef: "mock-claude" }));' \
-              > scripts/validate-claude.mjs
+          printf '%s\n' \
+            '#!/usr/bin/env node' \
+            'console.log(JSON.stringify({ vote: "approve", summary: "mock claude approve", evidenceRef: "mock-claude" }));' \
+            > scripts/validate-claude.mjs
 
-            printf '%s\n' \
-              '#!/usr/bin/env node' \
-              'console.log(JSON.stringify({ vote: "approve", summary: "mock gemini approve", evidenceRef: "mock-gemini" }));' \
-              > scripts/validate-gemini.mjs
+          printf '%s\n' \
+            '#!/usr/bin/env node' \
+            'console.log(JSON.stringify({ vote: "approve", summary: "mock gemini approve", evidenceRef: "mock-gemini" }));' \
+            > scripts/validate-gemini.mjs
 
-            chmod +x scripts/validate-claude.mjs scripts/validate-gemini.mjs
-          fi
+          chmod +x scripts/validate-claude.mjs scripts/validate-gemini.mjs
 
-      - name: Install advisor CLIs (external mode)
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.external_advisors == true }}
-        run: npm install --global @anthropic-ai/claude-code @google/gemini-cli
-
-      - name: Run release gate
+      - name: Run release gate (mock advisors, no external API keys)
         shell: bash
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
           node scripts/release-gate.mjs \
             --plan .salacia/plans/release-gate-plan.json \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Install advisor CLIs
-        run: npm install --global @anthropic-ai/claude-code @google/gemini-cli
-
       - name: Prepare gate fixtures
         shell: bash
         run: |
@@ -60,12 +57,23 @@ jobs:
           }
           JSON
 
-      - name: Run release gate (external advisors required)
+      - name: Prepare advisors (mock-only)
         shell: bash
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          printf '%s\n' \
+            '#!/usr/bin/env node' \
+            'console.log(JSON.stringify({ vote: "approve", summary: "mock claude approve", evidenceRef: "mock-claude" }));' \
+            > scripts/validate-claude.mjs
+
+          printf '%s\n' \
+            '#!/usr/bin/env node' \
+            'console.log(JSON.stringify({ vote: "approve", summary: "mock gemini approve", evidenceRef: "mock-gemini" }));' \
+            > scripts/validate-gemini.mjs
+
+          chmod +x scripts/validate-claude.mjs scripts/validate-gemini.mjs
+
+      - name: Run release gate (mock advisors, no external API keys)
+        shell: bash
         run: |
           node scripts/release-gate.mjs \
             --plan .salacia/plans/release-gate-plan.json \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Hotfix: normalize restored snapshot line ending assertion for Windows CI.
 - Confirmed `main` cross-platform matrix green after v0.1.1 merge.
+- Changed GitHub Release Gate/Release workflows to mock-advisor-only mode (no external advisor API keys in CI).
 
 ## 0.1.1 - 2026-02-21
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Rules:
 - 2/3 majority required (`approve` or `reject`)
 - split/abstain outcome requires human approval
 - release gate fails on missing advisor evidence, malformed advisor output, or unresolved split
+- GitHub workflows use deterministic mock advisor scripts only (no external advisor API calls)
 
 ## Security Model
 
@@ -103,6 +104,7 @@ Rules:
 - Claude calls only set `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` at invocation time
 - Secret scan is part of CI and release gate
 - Protected paths can be blocked through contract guardrails
+- GitHub workflows do not inject external advisor API keys for convergence checks
 
 See [SECURITY.md](SECURITY.md) for incident response and key rotation.
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -35,11 +35,17 @@ salacia prompt optimize --from-journal --json
 node scripts/release-gate.mjs --plan <plan.json> --exec <exec.json> --require-convergence
 ```
 
-Optional local-only mode without external advisors:
+Local-only mode without external advisors:
 
 ```bash
 node scripts/release-gate.mjs --plan <plan.json> --exec <exec.json> --require-convergence --no-external
 ```
+
+GitHub Actions policy:
+
+- Release Gate and Release workflows run mock advisor scripts only.
+- No external advisor API keys are injected in GitHub workflows.
+- External advisor validation remains a local/operator action, outside GitHub CI environment.
 
 Consistency safety net check:
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -19,6 +19,7 @@
 - prompt metamorphic checks passed
 - no unresolved split
 - advisor evidence present
+- GitHub release workflows use mock advisors only and do not inject external API keys
 
 ## Commands
 


### PR DESCRIPTION
## Summary
- enforce mock advisor scripts in .github/workflows/release-gate.yml and .github/workflows/release.yml
- remove external advisor CLI install and GitHub secret env injection from release workflows
- document policy: external advisor convergence is local-only, GitHub uses deterministic mocks

## Validation
- npm run lint
- npm test